### PR TITLE
Makes <h2> semi-bold

### DIFF
--- a/static/less/base.less
+++ b/static/less/base.less
@@ -76,7 +76,7 @@ h1 {
 }
 
 h2 {
-  font-family: nimbussannov-bol;
+  font-family: nimbussannov-sembol;
   font-weight: normal;
   font-size: 24px;
   color: #000;


### PR DESCRIPTION
This changes the CSS font-family for the `<h2>` headers to be semi-bold as per ticket https://github.com/balanced/balanced-dashboard/issues/218.
