### PR TITLE
Proper tests for add and widthdraw funds.

### DIFF
--- a/test/integration/activity.js
+++ b/test/integration/activity.js
@@ -48,14 +48,14 @@ test('add funds', function(assert) {
 
     assert.equal($('#add-funds').css('display'), 'block', 'add funds modal visible');
 
-    // assert.notEqual($('#add-funds select option').length, 0, 'at least one bank account in account dropdown');
+    assert.equal($('#add-funds select option').length, 2, 'two verified bank account in account dropdown');
 
-    // $('#add-funds input').first().val('55.55');
-    // $('#add-funds .modal-footer .btn').not('.danger').click();
+    $('#add-funds input').first().val('55.55').trigger('keyup');
+    $('#add-funds .modal-footer .btn').not('.danger').click();
 
-    // assert.equal($('#add-funds').css('display'), 'none', 'add funds modal hidden');
+    assert.equal($('#add-funds').css('display'), 'none', 'add funds modal hidden');
 
-    //assert.notEqual($('.activity-escrow-box .amount .number1d').html().indexOf('1137.81'), -1, 'escrow amount is now $1193.36');
+    //assert.notEqual($('.activity-escrow-box .amount .number1d').html().indexOf('1,193.36'), -1, 'escrow amount is now $1,193.36');
 });
 
 test('withdraw funds', function(assert) {
@@ -65,13 +65,13 @@ test('withdraw funds', function(assert) {
 
     assert.equal($('#withdraw-funds').css('display'), 'block', 'withdraw funds modal visible');
 
-    // assert.notEqual($('#withdraw-funds select option').length, 0, 'at least one bank account in account dropdown');
+    assert.equal($('#withdraw-funds select option').length, 2, 'two bank account in account dropdown');
 
-    // $('#withdraw-funds input').first().val('55.55');
-    // $('#withdraw-funds .modal-footer .btn').not('.danger').click();
+    $('#withdraw-funds input').first().val('55.55').trigger('keyup');
+    $('#withdraw-funds .modal-footer .btn').not('.danger').click();
 
-    // assert.equal($('#withdraw-funds').css('display'), 'none', 'withdraw funds modal hidden');
+    assert.equal($('#withdraw-funds').css('display'), 'none', 'withdraw funds modal hidden');
 
-    //assert.notEqual($('.activity-escrow-box .amount .number1d').html().indexOf('1082.26'), -1, 'escrow amount is now $1082.26');
+    //assert.notEqual($('.activity-escrow-box .amount .number1d').html().indexOf('1,082.26'), -1, 'escrow amount is now $1,082.26');
 });
 

--- a/test/integration/marketplace_settings.js
+++ b/test/integration/marketplace_settings.js
@@ -32,7 +32,8 @@ test('can update marketplace info', function (assert) {
 test('can create bank accounts', function (assert) {
     var createsBefore = Balanced.Adapter.creates.length;
 
-    assert.equal($('.bank-account-info .sidebar-items li').length, 0);
+    // There are two bank accounts added to the fixture, used for add and withdraw funds
+    assert.equal($('.bank-account-info .sidebar-items li').length, 2);
 
     // click the button to add a bank account
     $('.bank-account-info a.add').click();

--- a/test/support/fixtures/marketplace.js
+++ b/test/support/fixtures/marketplace.js
@@ -10,30 +10,119 @@ Balanced.Adapter.addFixtures([{
 ]);
 
 Balanced.Adapter.addFixtures([
-	{
-		uri: "/v1/marketplaces/MP1/callbacks",
-		items: []
-	},
-	{
-		uri: "/v1/marketplaces/MP2/callbacks",
-		items: []
-	},
-	{
-		uri: "/v1/marketplaces/MP5m04ORxNlNDm1bB7nkcgSY/callbacks",
-		items: [{
-			method: "post",
-			url: "http://balancedpayments.com"
-		}, {
-			method: "post",
-			url: "http://example.com"
-		}]
-	},
-	{
-		uri: '/v1/customers/CU1DkfCFcAemmM99fabUso2c/bank_accounts',
-		items: []
-	},
-	{
-		uri: '/v1/customers/CU1DkfCFcAemmM99fabUso2c/cards',
-		items: []
-	}
+  {
+    uri: "/v1/marketplaces/MP1/callbacks",
+    items: []
+  },
+  {
+    uri: "/v1/marketplaces/MP2/callbacks",
+    items: []
+  },
+  {
+    uri: "/v1/marketplaces/MP5m04ORxNlNDm1bB7nkcgSY/callbacks",
+    items: [{
+      method: "post",
+      url: "http://balancedpayments.com"
+    }, {
+      method: "post",
+      url: "http://example.com"
+    }]
+  },
+  {
+    uri: '/v1/customers/CU1DkfCFcAemmM99fabUso2c/bank_accounts',
+    items: [
+      {
+        "default_credit": true,
+        "can_hold": false,
+        "meta": {
+
+        },
+        "routing_number": "123456789",
+        "id": "BA5r9JGZJ7YOCiULGthQYjVc",
+        "is_valid": true,
+        "verifications_uri": "/v1/bank_accounts/BA5r9JGZJ7YOCiULGthQYjVc/verifications",
+        "type": "checking",
+        "bank_name": null,
+        "_type": "bank_account",
+        "bank_code": "123456789",
+        "default_debit": true,
+        "_uris": {
+            "verification_uri": {
+                "_type": "bank_account_authentication",
+                "key": "verification"
+            },
+            "transactions_uri": {
+                "_type": "page",
+                "key": "transactions"
+            },
+            "verifications_uri": {
+                "_type": "page",
+                "key": "verifications"
+            },
+            "credits_uri": {
+                "_type": "page",
+                "key": "credits"
+            }
+        },
+        "last_four": "5555",
+        "fingerprint": "16igBKFBfrx4xoUvatqJFz",
+        "can_debit": true,
+        "credits_uri": "/v1/bank_accounts/BA5r9JGZJ7YOCiULGthQYjVc/credits",
+        "customer": null,
+        "verification_uri": "/v1/bank_accounts/BA5r9JGZJ7YOCiULGthQYjVc/verifications/BZ5s80nhCfSdQAQKjk3PXDT9",
+        "transactions_uri": "/v1/bank_accounts/BA5r9JGZJ7YOCiULGthQYjVc/transactions",
+        "name": "Test",
+        "can_credit": true,
+        "created_at": "2013-07-02T18:03:28.465726Z",
+        "uri": "/v1/customers/CU1DkfCFcAemmM99fabUso2c/bank_accounts/BA5r9JGZJ7YOCiULGthQYjVc",
+        "account_number": "xxxxxxxxx5555"
+      },
+      {
+        "default_credit": false,
+        "can_hold": false,
+        "meta": {
+
+        },
+        "routing_number": "121042882",
+        "id": "BA5nPKKnltzJAAEiWWnnZHBg",
+        "is_valid": true,
+        "verifications_uri": "/v1/bank_accounts/BA5nPKKnltzJAAEiWWnnZHBg/verifications",
+        "type": "checking",
+        "bank_name": "WELLS FARGO BANK NA",
+        "_type": "bank_account",
+        "bank_code": "121042882",
+        "default_debit": false,
+        "_uris": {
+            "transactions_uri": {
+                "_type": "page",
+                "key": "transactions"
+            },
+            "verifications_uri": {
+                "_type": "page",
+                "key": "verifications"
+            },
+            "credits_uri": {
+                "_type": "page",
+                "key": "credits"
+            }
+        },
+        "last_four": "5555",
+        "fingerprint": "6ybvaLUrJy07phK2EQ7pVk",
+        "can_debit": true,
+        "credits_uri": "/v1/bank_accounts/BA5nPKKnltzJAAEiWWnnZHBg/credits",
+        "customer": null,
+        "verification_uri": null,
+        "transactions_uri": "/v1/bank_accounts/BA5nPKKnltzJAAEiWWnnZHBg/transactions",
+        "name": "TEST-MERCHANT-BANK-ACCOUNT",
+        "can_credit": true,
+        "created_at": "2013-06-28T01:18:51.099402Z",
+        "uri": "/v1/customers/CU1DkfCFcAemmM99fabUso2c/bank_accounts/BA5nPKKnltzJAAEiWWnnZHBg",
+        "account_number": "xxxxxxxxxxx5555"
+      }
+    ]
+  },
+  {
+    uri: '/v1/customers/CU1DkfCFcAemmM99fabUso2c/cards',
+    items: []
+  }
 ]);


### PR DESCRIPTION
Missing the last check to make sure the balance actually updates, but I believe this is because the test needs to wait for the actual AJAX request to finish. At least now, it checks to make sure there are bank accounts in the select, etc.
