### PR TITLE
Fix #408 customer CSV export bug

### DIFF
--- a/app/controllers/mixins/downloads.js
+++ b/app/controllers/mixins/downloads.js
@@ -1,6 +1,7 @@
 Balanced.DownloadControllerMixin = Ember.Mixin.create({
     needs: ['marketplace'],
 
+    download_model: null, 
     show_download: false,
 
     openDownload: function () {
@@ -9,7 +10,7 @@ Balanced.DownloadControllerMixin = Ember.Mixin.create({
             uri: uri,
             email_address: null
         });
-        this.set('model', download);
+        this.set('download_model', download);
         this.set('show_download', true);
     },
 
@@ -18,13 +19,13 @@ Balanced.DownloadControllerMixin = Ember.Mixin.create({
     },
 
     download: function () {
-        if (this.get('model.isSaving')) {
+        if (this.get('download_model.isSaving')) {
             return;
         }
 
-        if (this.get('model.email_address')) {
+        if (this.get('download_model.email_address')) {
             var self = this;
-            this.get('model').create().then(function () {
+            this.get('download_model').create().then(function () {
                 self.closeDownload();
                 self.confirmDownload();
             });

--- a/app/templates/modals/_download.hbs
+++ b/app/templates/modals/_download.hbs
@@ -7,7 +7,7 @@
         <div class="modal-body">
             <p class="body2a">A CSV file of your current data set will be sent to:</p>
             <label>Email</label>
-            {{view Ember.TextField name="email" valueBinding="model.email_address" type="email" class="full"}}
+            {{view Ember.TextField name="email" valueBinding="download_model.email_address" type="email" class="full"}}
         </div>
         <div class="modal-footer">
             {{view Balanced.ModalActionButtonsView submitTitle="Export"}}


### PR DESCRIPTION
I try to this the issue with minimum effort. I think it might need some refactory. I traced it and noticed that the download controller mixin sets `model` attribute to `Balanced.Download` object. 

```
Balanced.DownloadControllerMixin = Ember.Mixin.create({
    needs: ['marketplace'],

    download_model: null, 
    show_download: false,

    openDownload: function () {
        var uri = this.getSearchUri();
        var download = Balanced.Download.create({
            uri: uri,
            email_address: null
        });
        this.set('model', download);  // <----- here it is
        this.set('show_download', true);
    },
```

I don't think it is a correct way to do, as it overwrites original model object of customer controller (and all other controllers), which might servers other purpose. When the `model` object is set by download controller mixin, some black magic happens behind the scene (I don't really like these magic behaviors, those Ember.Bind things, explicit is better than implicit :S). Eventually, the `transactions` attribute is updated in a wrong way, leads to updating view, that's why the transaction data disappears from the UI. 

I set it as `download_model` instead of `model`

```
this.set('download_model', download);
```

This should work, however, I feel the download modal should be implemented as a view object instead of a controller mixin as all other modal views did.
