### PR TITLE
Fixes #436 - Change URL desintation to dashboard activity page for the logo icon

### DIFF
--- a/app/templates/_header.hbs
+++ b/app/templates/_header.hbs
@@ -2,7 +2,7 @@
     <div class="row">
 
         <div id="logo" class="span2">
-            {{#linkTo 'activity.index' class="img"}}Register{{/linkTo}}
+            {{#linkTo 'index' class="img"}}Balanced Dashboard{{/linkTo}}
         </div>
 
         {{#if Balanced.Auth.isGuest}}


### PR DESCRIPTION
Just used the linked to filter and pointed to activities index, should do the trick
