### PR TITLE
Fix navigation hover inconsistency fixes #523

### DIFF
--- a/static/less/scaffolding.less
+++ b/static/less/scaffolding.less
@@ -421,7 +421,9 @@ footer {
       &.active {
         color: @black;
       }
-      &:hover {
+    }
+    &:hover {
+      > a, > span {
         color: @black;
       }
     }


### PR DESCRIPTION
That fixes it, hovering the whole `li` bring the text _and_ the icon to become black.
