### PR TITLE
Fixes #269 - Wrong icon for production marketplace

### DIFF
--- a/app/templates/marketplaces/index.hbs
+++ b/app/templates/marketplaces/index.hbs
@@ -15,7 +15,9 @@
                                 {{#each user_marketplace in Balanced.Auth.user.user_marketplaces }}
                                     {{#if user_marketplace.production }}
                                         <li>
-                                            <div class="icon"></div>
+                                            <div class="span2 label">
+                                                <div class="icon"></div>
+                                            </div>
                                             <div class="info">
                                                 <h3 class="label1d name">{{#linkTo 'activity' user_marketplace.id }}{{ user_marketplace.name }}{{/linkTo}}</h3>
                                             </div>
@@ -23,7 +25,9 @@
                                     {{/if}}
                                 {{/each}}
                                 <li class="new">
-                                    <div class="icon"></div>
+                                    <div class="span2 label">
+                                        <div class="icon"></div>
+                                    </div>
                                     <div class="info">
                                         {{view Balanced.AddExistingMarketplaceView}}
                                     </div>
@@ -38,7 +42,7 @@
                                         <li>
                                             <a href="#" class="icon-delete" {{action promptToDeleteMarketplace user_marketplace }}>&times;</a>
                                             <div class="icon"></div>
-                                                <div class="info">
+                                            <div class="info">
                                                 <h3 class="label1d name">{{#linkTo 'activity' user_marketplace.id }}{{ user_marketplace.name }}{{/linkTo}}</h3>
                                             </div>
                                         </li>

--- a/static/less/marketplace.less
+++ b/static/less/marketplace.less
@@ -60,6 +60,11 @@
       margin-bottom: 5px;
       width: 895px;
       position: relative;
+      .label{
+        width: 65px;
+        margin: 0;
+        height: 65px;
+      }
       .icon {
         float: left;
         .cssicon(
@@ -92,24 +97,29 @@
     &.production {
       li {
         background-color: @pineGreen60;
+        &.new{
+          .icon {
+            background-position: -43px -716px;
+          }
+        }
+      }
+      .label{
+        background-color: @pineGreen100;
       }
       .icon {
-        background-color: @pineGreen100;
-        &:before{
-          display: block;
-          position: relative;
-          top: 38px;
-          left: 29px;
-          content: '';
-          width: 6px;
-          height: 7px;
-          background-color: @pineGreen100;
-        }
+        background-position: 8px -716px;
+        height: 55px;
+        margin-top: 3px;
       }
     }
     &.test {
       li {
         background-color: @curryYellow60;
+        &.new{
+          .icon {
+            background-position: -43px -662px;
+          }
+        }
       }
       .icon {
         background-color: @curryYellow100;
@@ -117,12 +127,8 @@
     }
     li.new {
       background-color: @white;
-      .icon {
+      .icon, .label {
         background-color: @gray3;
-        background-position: -43px -662px;
-        &:before{
-          background-color: @gray3;
-        }
       }
     }
     &.register {


### PR DESCRIPTION
Decided to make the door out of CSS instead of the image for this one... This is because of the the sprites not being proportioned for our needs, while still using existing html structure. If we don't like this solution, I can modify the html structure.

Also, disregard the Grunt commits, they cancel each other out. It can be merged automatically with no issues.
