### PR TITLE
Fixed alignment of calendar drop down - Issue #564

### DIFF
--- a/static/less/results.less
+++ b/static/less/results.less
@@ -371,7 +371,7 @@ header.results-label h3 {
 
       &.date-picker {
         top: 48px;
-        right: -5px;
+        right: 0px;
       }
 
       .set-times {


### PR DESCRIPTION
Aligned the right side of the calendar drop down with the right side of
the white bar above it.
