### PR TITLE
fixes the coverage report that wasn't getting generated

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,6 @@ module.exports = function(config) {
       'build/test/js/testenv.js',
       'build/js/lib-dev.js',
       'build/js/dashboard-dev.js',
-      'build/js/dashboard-prod.js',
       'build/test/js/test-fixtures.js',
       'test/support/testconfig.js',
       'test/lib/helpers.js',
@@ -30,7 +29,7 @@ module.exports = function(config) {
     ],
 
     preprocessors: {
-      'build/js/dashboard-prod.js': ['coverage']
+      'build/js/dashboard-dev.js': ['coverage']
     },
 
     // test results reporter to use


### PR DESCRIPTION
Sometimes it's the little things.

Wanted to look at the coverage report and noticed we were running the coverage pre-processor against a file that wasn't included (that made it not work).

Now, it works!

Coverage looks good:

![screen shot 2013-10-01 at 9 36 08 pm](https://f.cloud.github.com/assets/689411/1251190/3220b5c6-2b1c-11e3-80a4-c4bb707b78f9.png)
