### PR TITLE
Show status of latest build from master only

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ balanced-dashboard
 
 The Balanced Dashboard
 
-[![Build Status](https://travis-ci.org/balanced/balanced-dashboard.png)](https://travis-ci.org/balanced/balanced-dashboard)
+[![Build Status](https://travis-ci.org/balanced/balanced-dashboard.png?branch=master)](https://travis-ci.org/balanced/balanced-dashboard)
 
 ## What
 


### PR DESCRIPTION
Before, it would show only the latest build from all branches, so that meant if rev1 was updated, it would show that the build is failing. 
