### PR TITLE
fix edit customer modal

### DIFF
--- a/app/views/customer/edit_customer_info_modal.js
+++ b/app/views/customer/edit_customer_info_modal.js
@@ -50,6 +50,10 @@ Balanced.EditCustomerInfoModalView = Balanced.View.extend({
 				customer.set('email', null);
 			}
 
+			if (customer.get('ssn_last4') === '') {
+				customer.set('ssn_last4', null);
+			}
+
 			customer.save().then(function() {
 				self.get('customer').reload();
 				$('#edit-customer-info').modal('hide');


### PR DESCRIPTION
This addresses issue #737 by setting the "ssn_last4" key to null if it's empty string. 
