### PR TITLE
Fix the issue of descenders of Marketplace Name getting cut-off in the Marketplace tab.

### DIFF
--- a/static/less/scaffolding.less
+++ b/static/less/scaffolding.less
@@ -179,6 +179,7 @@ footer {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    line-height: normal;
   }
   text-align: center;
   display: block;


### PR DESCRIPTION
<b>Before:</b>

![balanced - descenders issue 1](https://f.cloud.github.com/assets/3154126/1529099/0b868086-4c27-11e3-84df-6a9682ffa2e9.png)

<b>After:</b>

![balanced - descenders issue 2](https://f.cloud.github.com/assets/3154126/1529101/1796ca2a-4c27-11e3-8e60-cc04329dd5cf.png)
