### PR TITLE
Fixes #315 Scrolls to top error when submitting Production Access Form

### DIFF
--- a/app/controllers/marketplaces/apply.js
+++ b/app/controllers/marketplaces/apply.js
@@ -229,7 +229,9 @@ Balanced.MarketplacesApplyController = Balanced.ObjectController.extend({
 	},
 
 	highlightError: function() {
-		$('input', '#marketplace-apply .control-group.error:first').focus();
+		window.setTimeout(function() {
+			$('input', '#marketplace-apply .control-group.error:first').focus();
+		}, 0);
 	},
 
 	accountTypes: ['checking', 'savings'],


### PR DESCRIPTION
Issue was that the selector statement wasn't matching anything at the time it was executing. setTimeout(..., 0) pushes the call to the end so that ember has time to update the error class on the views.
