### PR TITLE
Filtering files with the file option #228

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -494,7 +494,33 @@ module.exports = function(grunt) {
 
 		karma: {
 			unit: {
-				configFile: 'karma.conf.js'
+				configFile: 'karma.conf.js',
+			},
+			options: {
+				port: 9877,
+				files: (function() {
+					var file = grunt.option("file");
+					var files = [
+						'build/css/base.min.css',
+						'build/test/js/sinon.js',
+						'build/test/js/testenv.js',
+						'build/js/lib-dev.js',
+						'test/support/lib/balanced.min.js',
+						'build/js/dashboard-dev.js',
+						'build/test/js/test-fixtures.js',
+						'test/support/testconfig.js',
+						'test/lib/*.js',
+					];
+
+					if (file) {
+						files.push(file);
+					} else {
+						files.push('test/unit/**/*');
+						files.push('test/integration/**/*');
+					}
+
+					return files;
+				})()
 			}
 		},
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,19 +11,7 @@ module.exports = function(config) {
 		frameworks: ['qunit'],
 
 		// list of files / patterns to load in the browser
-		files: [
-			'build/css/base.min.css',
-			'build/test/js/sinon.js',
-			'build/test/js/testenv.js',
-			'build/js/lib-dev.js',
-			'test/support/lib/balanced.min.js',
-			'build/js/dashboard-dev.js',
-			'build/test/js/test-fixtures.js',
-			'test/support/testconfig.js',
-			'test/lib/*.js',
-			'test/unit/**/*',
-			'test/integration/**/*'
-		],
+		files: [],
 
 		// list of files to exclude
 		exclude: [],


### PR DESCRIPTION
This allows for filtering the tests to a single glob pattern when using the command line:

```
# run only matching tests
grunt test --file=test/unit/models/**/*

# run all tests
grunt test
```
