### PR TITLE
Fix for Long bank names overflow

### DIFF
--- a/static/less/pages.less
+++ b/static/less/pages.less
@@ -133,6 +133,14 @@ section[class$="-info"] {
     .name {
       display: block;
     }
+
+    .summary {
+      float: left;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      width: 100%;
+      white-space: nowrap;
+    }
   }
   .actions {
     background-color: @itemIconBackground;


### PR DESCRIPTION
My first pull request :-). The string get's truncated without messing the height. Hope you guys find it useful. Based on http://css-tricks.com/snippets/css/truncate-string-with-ellipsis/. 

![screen shot 2014-05-15 at 7 35 16 pm](https://cloud.githubusercontent.com/assets/1330851/2985148/fbd3e3f6-dc39-11e3-9ae8-1e6f9265cebe.png)
