### PR TITLE
Display error description for logs

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -426,6 +426,13 @@ Balanced.Utils = Ember.Namespace.create({
 		});
 
 		return formattedBankName;
-	}
+	},
 
+	formatStatusCode: function(statusCode) {
+		if (statusCode) {
+			return Balanced.Utils.capitalize(statusCode.replace(/-/g, ' '));
+		} else {
+			return null;
+		}
+	}
 });

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -14,6 +14,12 @@ Balanced.Log = Balanced.Model.extend({
 		}
 	}.property('status_rollup'),
 
+	status_code: Ember.computed.alias('message.response.status'),
+
+	// Handling the difference between rev 1.0 and 1.1
+	category_code: Balanced.computed.orProperties('message.response.body.category_code', 'message.response.body.errors.0.category_code'),
+	description: Balanced.computed.orProperties('message.response.body.description', 'message.response.body.errors.0.description'),
+
 	geo_ip: function() {
 		var ip = this.get('message.request.headers.X-Real-Ip');
 

--- a/app/templates/log.hbs
+++ b/app/templates/log.hbs
@@ -9,9 +9,11 @@
 		<dt>URI</dt>
 		<dd><span>{{model.short_url}}</span></dd>
 		<dt>Status</dt>
-		<dd><span>{{colorizeStatus model.message.response.status}}</span></dd>
+		<dd><span>{{colorizeStatus model.status_code}}</span></dd>
+		<dt>Category code</dt>
+		<dd>{{model.category_code}}</dd>
 		<dt>Description</dt>
-		<dd>{{model.message.response.body.errors.0.description}}</dd>
+		<dd>{{model.description}}</dd>
 		<dt>Request ID</dt>
 		<dd data-property="request-id"><span>{{model.guru_id}}</span></dd>
 		<dt>IP address</dt>

--- a/app/views/tables/logs_table_cell_view.js
+++ b/app/views/tables/logs_table_cell_view.js
@@ -17,14 +17,8 @@ Balanced.LogStatusCellView = Balanced.LinkedTextCellView.extend({
 	routeName: Ember.computed.oneWay("item.route_name"),
 	classNameBindings: [":black"],
 	isBlank: false,
-	primaryLabelText: Ember.computed.oneWay('item.message.response.status'),
-	secondaryLabelText: function() {
-		if (this.get('item.message.response.body.errors')) {
-			return this.get('item.message.response.body.errors.0.description');
-		} else {
-			return undefined;
-		}
-	}.property('item.message.response.body.errors.status'),
+	primaryLabelText: Ember.computed.oneWay('item.status_code'),
+	secondaryLabelText: Balanced.computed.transform('item.category_code', Balanced.Utils.formatStatusCode),
 
 	spanClassNames: function() {
 		return this.get('primaryLabelText').match(/2\d\d/) ? 'succeeded' : 'failed';


### PR DESCRIPTION
I liked how it used to return `category_code` with a short summary, but the API has changed and it no longer provides the summary.
