### PR TITLE
Hide the reverse button on a credit for debit cards

### DIFF
--- a/app/models/credit.js
+++ b/app/models/credit.js
@@ -39,8 +39,8 @@ Balanced.Credit = Balanced.Transaction.extend({
 	}.on('didLoad'),
 
 	can_reverse: function() {
-		return (!this.get('is_failed')) && (this.get('reversal_amount') > 0);
-	}.property('is_failed', 'reversal_amount'),
+		return (!this.get('is_failed')) && (this.get('reversal_amount') > 0 && this.get('funding_instrument_type') !== 'Debit card');
+	}.property('is_failed', 'reversal_amount', 'funding_instrument_type'),
 
 	status_description: function() {
 		if (this.get('is_pending')) {


### PR DESCRIPTION
- Check if the funding instrument for a credit is a debit card
- Do not show the reverse button for those credits

Closes balanced/balanced-dashboard#1477
