### PR TITLE
Add UPS tracking number

### DIFF
--- a/app/templates/modals/evidence-portal-modal.hbs
+++ b/app/templates/modals/evidence-portal-modal.hbs
@@ -44,7 +44,7 @@
 {{/view}}
 
 {{#view "form-fields/form-section" model=view.model sectionTitle="Tracking information" sectionDescription=view.trackingCodeText}}
-	{{view "form-fields/text-form-field" model=view.model inputClassNames="full" inputName="tracking_number" field="tracking_number" labelText="Tracking number" explanationText="FedEx or USPS tracking number only"}}
+	{{view "form-fields/text-form-field" model=view.model inputClassNames="full" inputName="tracking_number" field="tracking_number" labelText="Tracking number" explanationText="FedEx, UPS or USPS tracking number only"}}
 {{/view}}
 
 {{#view "form-fields/form-section" model=view.model sectionTitle="Evidence description" sectionDescription=view.noteText}}


### PR DESCRIPTION
@kyungmin 

Justitia can also handle UPS screenshot now, so I just added it in the tracking number field explanation text.
